### PR TITLE
Minor fixes needed for system tests 

### DIFF
--- a/charts/bctlquickstart/bctl-quickstart/bctl_quickstart/bctl_quickstart/utils.py
+++ b/charts/bctlquickstart/bctl-quickstart/bctl_quickstart/bctl_quickstart/utils.py
@@ -129,12 +129,15 @@ def makeJsonPostRequest(endpoint, apiKey, json={}):
     :param dict json: Optional json data
     """
     headers = {'X-API-KEY': apiKey, 'Content-Type': 'application/json'}
-    toReturn = requests.post(
+
+    resp = requests.post(
         f'{BASE_URL}/{endpoint}',
         headers=headers,
         json=json
-    ).json()
+    )
+    resp.raise_for_status()
 
+    toReturn = resp.json()
     if type(toReturn) is not list and 'errorType' in toReturn.keys():
         logging.error(f'Error making post request for endpoint: {endpoint}. Error: {toReturn["errorMsg"]}')
         raise Exception()
@@ -149,12 +152,14 @@ def makeDataGetRequest(endpoint, apiKey, data={}):
     :param dict json: Optional json data
     """
     headers = {'X-API-KEY': apiKey, 'Content-Type': 'application/json'}
-    toReturn = requests.get(
+    resp = requests.get(
         f'{BASE_URL}/{endpoint}',
         headers=headers,
         data=data
-    ).json()
-
+    )
+    resp.raise_for_status()
+    
+    toReturn = resp.json()
     if type(toReturn) is not list and 'errorType' in toReturn.keys():
         logging.error(f'Error making get request for endpoint: {endpoint}. Error: {toReturn["errorMsg"]}')
         raise Exception()

--- a/charts/bctlquickstart/templates/_helpers.tpl
+++ b/charts/bctlquickstart/templates/_helpers.tpl
@@ -76,14 +76,14 @@ Create the bctl-quickstart-job name
 Create the bctl-quickstart-Role name
 */}}
 {{- define "bctlquickstartchart.quickstartRoleName" -}}
-{{- "(include bctlquickstartchart.quickstartServiceAccountName .)-role" }}
+{{- printf "%s-role" (include "bctlquickstartchart.quickstartServiceAccountName" .) }}
 {{- end }}
 
 {{/*
 Create the bctl-quickstart-RoleBinding name
 */}}
 {{- define "bctlquickstartchart.quickstartRoleBindingName" -}}
-{{- "(include bctlquickstartchart.quickstartServiceAccountName .)-rolebinding" }}
+{{- printf "%s-rolebinding" (include "bctlquickstartchart.quickstartServiceAccountName" .) }}
 {{- end }}
 
 

--- a/charts/bctlquickstart/templates/agent/bctl-agent-deployment.yaml
+++ b/charts/bctlquickstart/templates/agent/bctl-agent-deployment.yaml
@@ -33,11 +33,11 @@ spec:
               - name: DEV
                 value: "true"
               - name: SERVICE_URL
-                value: "{{ required "A valid .Values.serviceUrl entry required!" .Values.serviceUrl }}"
+                value: ""
               - name: ACTIVATION_TOKEN
                 value: ""
               - name: CLUSTER_NAME
-                value: "{{ required "A valid .Values.clusterName entry required!" .Values.clusterName }}"
+                value: ""
               - name: CLUSTER_ID
                 value: ""
               - name: ORG_ID
@@ -47,7 +47,7 @@ spec:
               - name: IDP_PROVIDER
                 value: ""
               - name: IDP_CUSTOM_ISSUER
-                value: "$IDP_CUSTOM_ISSUER"
+                value: ""
               - name: ENVIRONMENT
                 value: ""
               - name: NAMESPACE

--- a/charts/bctlquickstart/templates/quickstart/bctl-quickstart-job.yaml
+++ b/charts/bctlquickstart/templates/quickstart/bctl-quickstart-job.yaml
@@ -5,10 +5,10 @@ metadata:
   name: {{ include "bctlquickstartchart.quickstartJobName" . }}
   labels:
     {{- include "bctlquickstartchart.labels" . | nindent 4 }}
-  {{- with .Values.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded
   namespace: {{ include "bctlquickstartchart.namespace" . }}
 spec:
     backoffLimit: 0

--- a/charts/bctlquickstart/templates/quickstart/bctl-quickstart-job.yaml
+++ b/charts/bctlquickstart/templates/quickstart/bctl-quickstart-job.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "bctlquickstartchart.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": post-install
-    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": hook-succeeded
   namespace: {{ include "bctlquickstartchart.namespace" . }}
 spec:

--- a/charts/bctlquickstart/templates/quickstart/bctl-quickstart-job.yaml
+++ b/charts/bctlquickstart/templates/quickstart/bctl-quickstart-job.yaml
@@ -34,7 +34,7 @@ spec:
               - name: QUICKSTART_JOB_NAME
                 value: "{{ include "bctlquickstartchart.quickstartJobName" . }}"
               - name: SERVICE_URL
-                value: "https://{{ required "A valid .Values.serviceUrl entry required!" .Values.serviceUrl }}"
+                value: "{{ required "A valid .Values.serviceUrl entry required!" .Values.serviceUrl }}"
               command: 
               - bctl-quickstart
               args:

--- a/charts/bctlquickstart/values.yaml
+++ b/charts/bctlquickstart/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: bastionzero/bctl-quickstart
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "1.0.0" # For our quickstart job
+  tag: 1.1.0 # For our quickstart job
   agentTag: "latest" # For our actual agent
 
 imagePullSecrets: []

--- a/charts/bctlquickstart/values.yaml
+++ b/charts/bctlquickstart/values.yaml
@@ -74,4 +74,4 @@ tolerations: []
 
 affinity: {}
 
-serviceUrl: "cloud.bastionzero.com"
+serviceUrl: "https://cloud.bastionzero.com"


### PR DESCRIPTION
## Description of the change

+ Converts the bctlquickstart job into a post-install hook so that the helm release will only complete once the post-install job completes.

+ Removes  implicit `https://` prefix from the serviceUrl helm variable. This makes it easier to pass the full service url in when we are getting it directly from zli configService.

## Relevant release note information

Release Notes:

## Related JIRA tickets

Relates to JIRA: CWC-1321

## Have you considered the security impacts?

Does this PR have any security impact?

- [ ] Yes
- [x] No

If yes, please explain: