### PR TITLE
Namespace change + Specify imagePullSecerets + agentName

### DIFF
--- a/charts/bctlquickstart/Chart.yaml
+++ b/charts/bctlquickstart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bctlquickstart/templates/_helpers.tpl
+++ b/charts/bctlquickstart/templates/_helpers.tpl
@@ -59,13 +59,6 @@ Create the name of the quickstart service account to use
 {{- end }}
 
 {{/*
-Create the namespace
-*/}}
-{{- define "bctlquickstartchart.namespace" -}}
-{{- .Values.namespace }}
-{{- end }}
-
-{{/*
 Create the bctl-quickstart-job name
 */}}
 {{- define "bctlquickstartchart.quickstartJobName" -}}

--- a/charts/bctlquickstart/templates/agent/bctl-agent-clusterrole.yaml
+++ b/charts/bctlquickstart/templates/agent/bctl-agent-clusterrole.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  namespace: {{ include "bctlquickstartchart.namespace" . }}
+  namespace: {{ .Release.Namespace }}
 rules:
     - apiGroups: [""]
       resources: ["users", "groups", "serviceaccounts"]

--- a/charts/bctlquickstart/templates/agent/bctl-agent-clusterrolebinding.yaml
+++ b/charts/bctlquickstart/templates/agent/bctl-agent-clusterrolebinding.yaml
@@ -8,10 +8,10 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  namespace: {{ include "bctlquickstartchart.namespace" . }}
+  namespace: {{ .Release.Namespace }}
 subjects:
     - kind: ServiceAccount
-      namespace: {{ include "bctlquickstartchart.namespace" . }}
+      namespace: {{ .Release.Namespace }}
       name: {{ include "bctlquickstartchart.agentServiceAccountName" . }}
 roleRef:
     kind: ClusterRole

--- a/charts/bctlquickstart/templates/agent/bctl-agent-deployment.yaml
+++ b/charts/bctlquickstart/templates/agent/bctl-agent-deployment.yaml
@@ -20,9 +20,15 @@ spec:
                 app: {{ include "bctlquickstartchart.agentDeploymentName" . }}
         spec:
             serviceAccountName: {{ include "bctlquickstartchart.agentServiceAccountName" . }}
+            {{- if .Values.image.agentImagePullSecrets }}
+            imagePullSecrets:
+            {{- range .Values.image.agentImagePullSecrets }}
+              - name: {{ . }}
+            {{- end }}
+            {{- end }}
             containers:
             - name: bctl-agent
-              image: "bastionzero/bctl-agent:{{ required "A valid .Values.image.agentTag entry required!" .Values.image.agentTag }}"
+              image: "{{ required "A valid .Values.image.agentImageName entry required!" .Values.image.agentImageName}}:{{ required "A valid .Values.image.agentTag entry required!" .Values.image.agentTag }}"
               resources:
                 {{- toYaml .Values.agentResources | nindent 16 }}
               imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/charts/bctlquickstart/templates/agent/bctl-agent-deployment.yaml
+++ b/charts/bctlquickstart/templates/agent/bctl-agent-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  namespace: {{ include "bctlquickstartchart.namespace" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
     replicas: 1
     selector:
@@ -51,7 +51,7 @@ spec:
               - name: ENVIRONMENT
                 value: ""
               - name: NAMESPACE
-                value: {{ include "bctlquickstartchart.namespace" . }}
+                value: {{ .Release.Namespace }}
             {{- with .Values.nodeSelector }}
             nodeSelector:
                 {{- toYaml . | nindent 8 }}

--- a/charts/bctlquickstart/templates/agent/bctl-agent-deployment.yaml
+++ b/charts/bctlquickstart/templates/agent/bctl-agent-deployment.yaml
@@ -28,7 +28,7 @@ spec:
             {{- end }}
             containers:
             - name: bctl-agent
-              image: "{{ required "A valid .Values.image.agentImageName entry required!" .Values.image.agentImageName}}:{{ required "A valid .Values.image.agentTag entry required!" .Values.image.agentTag }}"
+              image: "{{ required "A valid .Values.image.agentImageName entry required!" .Values.image.agentImageName}}:{{ required "A valid .Values.image.agentImageTag entry required!" .Values.image.agentImageTag }}"
               resources:
                 {{- toYaml .Values.agentResources | nindent 16 }}
               imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/charts/bctlquickstart/templates/agent/bctl-agent-role.yaml
+++ b/charts/bctlquickstart/templates/agent/bctl-agent-role.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  namespace: {{ include "bctlquickstartchart.namespace" . }}
+  namespace: {{ .Release.Namespace }}
 rules:
     - apiGroups: [""]
       resources: ["secrets"]

--- a/charts/bctlquickstart/templates/agent/bctl-agent-rolebinding.yaml
+++ b/charts/bctlquickstart/templates/agent/bctl-agent-rolebinding.yaml
@@ -8,10 +8,10 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  namespace: {{ include "bctlquickstartchart.namespace" . }}
+  namespace: {{ .Release.Namespace }}
 subjects:
     - kind: ServiceAccount
-      namespace: {{ include "bctlquickstartchart.namespace" . }}
+      namespace: {{ .Release.Namespace }}
       name: {{ include "bctlquickstartchart.agentServiceAccountName" . }}
 roleRef:
     kind: Role

--- a/charts/bctlquickstart/templates/agent/bctl-agent-secret.yaml
+++ b/charts/bctlquickstart/templates/agent/bctl-agent-secret.yaml
@@ -8,6 +8,6 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  namespace: {{ include "bctlquickstartchart.namespace" . }}
+  namespace: {{ .Release.Namespace }}
 data:
   secret: Y29vbGJlYW5z

--- a/charts/bctlquickstart/templates/agent/bctl-agent-serviceaccount.yaml
+++ b/charts/bctlquickstart/templates/agent/bctl-agent-serviceaccount.yaml
@@ -8,4 +8,4 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  namespace: {{ include "bctlquickstartchart.namespace" . }}
+  namespace: {{ .Release.Namespace }}

--- a/charts/bctlquickstart/templates/namespace.yaml
+++ b/charts/bctlquickstart/templates/namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ include "bctlquickstartchart.namespace" . }}

--- a/charts/bctlquickstart/templates/quickstart/bctl-quickstart-job.yaml
+++ b/charts/bctlquickstart/templates/quickstart/bctl-quickstart-job.yaml
@@ -18,7 +18,7 @@ spec:
             restartPolicy: Never
             containers:
             - name: {{ .Chart.Name }}
-              image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              image: "{{ .Values.image.repository }}:{{ .Values.image.quickstartTag }}"
               resources:
                 {{- toYaml .Values.quickstartResources | nindent 16 }}
               imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/charts/bctlquickstart/templates/quickstart/bctl-quickstart-job.yaml
+++ b/charts/bctlquickstart/templates/quickstart/bctl-quickstart-job.yaml
@@ -9,7 +9,7 @@ metadata:
     "helm.sh/hook": post-install
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": hook-succeeded
-  namespace: {{ include "bctlquickstartchart.namespace" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
     backoffLimit: 0
     template:
@@ -30,7 +30,7 @@ spec:
               - name: DEPLOYMENT_NAME
                 value: "{{ include "bctlquickstartchart.agentDeploymentName" . }}"
               - name: NAMESPACE
-                value: "{{ include "bctlquickstartchart.namespace" . }}"
+                value: "{{ .Release.Namespace }}"
               - name: QUICKSTART_JOB_NAME
                 value: "{{ include "bctlquickstartchart.quickstartJobName" . }}"
               - name: SERVICE_URL

--- a/charts/bctlquickstart/templates/quickstart/bctl-quickstart-role.yaml
+++ b/charts/bctlquickstart/templates/quickstart/bctl-quickstart-role.yaml
@@ -9,7 +9,7 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  namespace: {{ include "bctlquickstartchart.namespace" . }}
+  namespace: {{ .Release.Namespace }}
 rules:
     - apiGroups: [""]
       resources: ["pods"]

--- a/charts/bctlquickstart/templates/quickstart/bctl-quickstart-rolebindings.yaml
+++ b/charts/bctlquickstart/templates/quickstart/bctl-quickstart-rolebindings.yaml
@@ -9,10 +9,10 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  namespace: {{ include "bctlquickstartchart.namespace" . }}
+  namespace: {{ .Release.Namespace }}
 subjects:
     - kind: ServiceAccount
-      namespace: {{ include "bctlquickstartchart.namespace" . }}
+      namespace: {{ .Release.Namespace }}
       name: {{ include "bctlquickstartchart.quickstartServiceAccountName" . }}
 roleRef:
     kind: Role

--- a/charts/bctlquickstart/templates/quickstart/bctl-quickstart-serviceaccount.yaml
+++ b/charts/bctlquickstart/templates/quickstart/bctl-quickstart-serviceaccount.yaml
@@ -9,5 +9,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  namespace: {{ include "bctlquickstartchart.namespace" . }}
+  namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/bctlquickstart/values.yaml
+++ b/charts/bctlquickstart/values.yaml
@@ -10,8 +10,9 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: "2.0.0" # For our quickstart job
   agentTag: "latest" # For our actual agent
+  agentImageName: bastionzero/bctl-agent # For our actual agent
+  agentImagePullSecrets: [] # For our actual agent
 
-imagePullSecrets: []
 nameOverride: "bctl-quickstart-app"
 fullnameOverride: "bctl-quickstart-chart"
 

--- a/charts/bctlquickstart/values.yaml
+++ b/charts/bctlquickstart/values.yaml
@@ -8,8 +8,8 @@ image:
   repository: bastionzero/bctl-quickstart
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "2.0.0" # For our quickstart job
-  agentTag: "latest" # For our actual agent
+  quickstartTag: "2.0.0" # For our quickstart job
+  agentImageTag: "latest" # For our actual agent
   agentImageName: bastionzero/bctl-agent # For our actual agent
   agentImagePullSecrets: [] # For our actual agent
 

--- a/charts/bctlquickstart/values.yaml
+++ b/charts/bctlquickstart/values.yaml
@@ -15,9 +15,6 @@ imagePullSecrets: []
 nameOverride: "bctl-quickstart-app"
 fullnameOverride: "bctl-quickstart-chart"
 
-# Namespace
-namespace: "bastionzero"
-
 # Annotations to add to our objects
 annotations: {}
 


### PR DESCRIPTION
Related PRs: https://github.com/bastionzero/zli/pull/316

## Description of the change

- Don't manage namespace with yaml. Use built-in helm support. Users can now deploy the kube agent in a namespace that already exists
- Add ability to specify agent image name (and therefore the repo to pull from) and `imagePullSecrets`

## Relevant release note information

Release Notes: Don't manage namespace with yaml. Add ability to specify agent image and imagePullSecrets. Rename image.tag --> image.quickstartTag. Rename image.agentTag --> image.agentImageTag

## Related JIRA tickets

Relates to JIRA: CWC-1545

## Have you considered the security impacts?

Does this PR have any security impact?

- [ ] Yes
- [x] No

If yes, please explain: