### PR TITLE
Remove job deletion code

### DIFF
--- a/charts/bctlquickstart/Chart.yaml
+++ b/charts/bctlquickstart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bctlquickstart/bctl-quickstart/bctl_quickstart/bctl_quickstart/main.py
+++ b/charts/bctlquickstart/bctl-quickstart/bctl_quickstart/bctl_quickstart/main.py
@@ -38,16 +38,13 @@ def cli(apiKey, clusterName, deploymentName, jobName, namespace, environment, us
     # Now add any users, targetUsers, targetGroups to the policy that was created
     if users:
         utils.addUsersToPolicy(users, clusterName, apiKey)
-    
-    if targetUsers: 
-        utils.addTargetUsersToPolicy(targetUsers, clusterName, apiKey)
-    
-    if targetGroups: 
-        utils.addTargetGroupsToPolicy(targetGroups, clusterName, apiKey)
-    
-    logging.info(f'Finished setting up agent: {clusterName}!')
 
-    # Now delete the job
-    utils.deleteJob(jobName, namespace)
+    if targetUsers:
+        utils.addTargetUsersToPolicy(targetUsers, clusterName, apiKey)
+
+    if targetGroups:
+        utils.addTargetGroupsToPolicy(targetGroups, clusterName, apiKey)
+
+    logging.info(f'Finished setting up agent: {clusterName}!')
 
     logging.info('Finishing running kubernetes agent quickstart!')

--- a/charts/bctlquickstart/bctl-quickstart/bctl_quickstart/bctl_quickstart/utils.py
+++ b/charts/bctlquickstart/bctl-quickstart/bctl_quickstart/bctl_quickstart/utils.py
@@ -18,26 +18,6 @@ TIMEOUT=300
 # Set our logging level
 logging.getLogger().setLevel(logging.INFO)
 
-
-def deleteJob(jobName, namespace):
-    """
-    Helper function to cleanup the Kube job (and along with it any traces of the API key)
-    :param str jobName: Job name to delete
-    :param str namespace: Namespace we are working inside
-    """
-    # Lets load our kube config
-    config.load_incluster_config()
-    batchApiClient = client.BatchV1Api()
-
-    # Delete our job now
-    logging.info(f'Deleting job: {jobName}...')
-
-    # Ref: https://github.com/kubernetes-client/python/issues/234
-    body = client.V1DeleteOptions(propagation_policy='Background')
-
-    batchApiClient.delete_namespaced_job(name=jobName, namespace=namespace, body=body)
-    
-
 def addUsersToPolicy(users, clusterName, apiKey):
     """
     Helper function to add users to a policy

--- a/charts/bctlquickstart/templates/quickstart/bctl-quickstart-job.yaml
+++ b/charts/bctlquickstart/templates/quickstart/bctl-quickstart-job.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install
     "helm.sh/hook-weight": "0"
-    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   namespace: {{ .Release.Namespace }}
 spec:
     backoffLimit: 0

--- a/charts/bctlquickstart/templates/quickstart/bctl-quickstart-job.yaml
+++ b/charts/bctlquickstart/templates/quickstart/bctl-quickstart-job.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install
     "helm.sh/hook-weight": "0"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
   namespace: {{ .Release.Namespace }}
 spec:
     backoffLimit: 0


### PR DESCRIPTION
## Description of the change

Don't delete kubernetes job as part of the code run in the pod spawned by the job. This behavior is confusing, probably unnecessary as the job is automatically cleaned up, and also breaks tools like ArgoCD that see the job as deleted before it can be cleaned up by ArgoCD.

## Relevant release note information

Release Notes:

## Related JIRA tickets

Relates to JIRA: CWC-XXX

## Have you considered the security impacts?

Does this PR have any security impact?

- [ ] Yes
- [ ] No

If yes, please explain:

fixes #12 