### PR TITLE
feat: add priorityClass support

### DIFF
--- a/charts/bctlquickstart/templates/agent/bctl-agent-deployment.yaml
+++ b/charts/bctlquickstart/templates/agent/bctl-agent-deployment.yaml
@@ -26,7 +26,9 @@ spec:
               - name: {{ . }}
             {{- end }}
             {{- end }}
+            {{- if .Values.priorityClass }}
             priorityClassName: {{ .Values.priorityClass }}
+            {{- end }}
             containers:
             - name: bctl-agent
               image: "{{ required "A valid .Values.image.agentImageName entry required!" .Values.image.agentImageName}}:{{ required "A valid .Values.image.agentImageTag entry required!" .Values.image.agentImageTag }}"

--- a/charts/bctlquickstart/templates/agent/bctl-agent-deployment.yaml
+++ b/charts/bctlquickstart/templates/agent/bctl-agent-deployment.yaml
@@ -26,6 +26,7 @@ spec:
               - name: {{ . }}
             {{- end }}
             {{- end }}
+            priorityClassName: {{ .Values.priorityClass }}
             containers:
             - name: bctl-agent
               image: "{{ required "A valid .Values.image.agentImageName entry required!" .Values.image.agentImageName}}:{{ required "A valid .Values.image.agentImageTag entry required!" .Values.image.agentImageTag }}"

--- a/charts/bctlquickstart/values.yaml
+++ b/charts/bctlquickstart/values.yaml
@@ -66,6 +66,8 @@ agentResources:
     cpu: 1
     memory: 1G
 
+priorityClass: "system-cluster-critical"
+
 quickstartResources: 
   limits:
     cpu: 1


### PR DESCRIPTION
## Description of the change

This adds priorityClass support to the helmchart and sets the default priorityClass to be system-cluster-critical. https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/ and https://kubernetes.io/blog/2023/01/12/protect-mission-critical-pods-priorityclass/ talk about why this is important.

## Relevant release note information

Release Notes: Adds support for Pod PriorityClass and sets default to "system-cluster-critical".

## Related JIRA tickets

## Have you considered the security impacts?

Does this PR have any security impact?

- [ ] Yes
- [x] No

If yes, please explain: