### PR TITLE
Add support for agent deployment replicaCount + topologySpreadConstraints

### DIFF
--- a/charts/bctlquickstart/Chart.yaml
+++ b/charts/bctlquickstart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.0
+version: 2.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/bctlquickstart/example/multiple-replica.yaml
+++ b/charts/bctlquickstart/example/multiple-replica.yaml
@@ -1,0 +1,14 @@
+replicaCount: 2
+
+clusterName: bz-multi-replica-example
+apiKey: <registration-api-key-goes-here>
+
+agent:
+  deploymentName: bz-agent
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: DoNotSchedule
+      labelSelector:
+        matchLabels:
+          app: bz-agent

--- a/charts/bctlquickstart/templates/_helpers.tpl
+++ b/charts/bctlquickstart/templates/_helpers.tpl
@@ -55,7 +55,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the quickstart service account to use
 */}}
 {{- define "bctlquickstartchart.quickstartServiceAccountName" -}}
-{{- .Values.quickstart.quickstartServiceAccount }}
+{{- default (print "bctl-" .Values.clusterName "-quickstart-sa")  .Values.quickstart.quickstartServiceAccount }}
 {{- end }}
 
 {{/*

--- a/charts/bctlquickstart/templates/agent/bctl-agent-deployment.yaml
+++ b/charts/bctlquickstart/templates/agent/bctl-agent-deployment.yaml
@@ -10,7 +10,7 @@ metadata:
   {{- end }}
   namespace: {{ .Release.Namespace }}
 spec:
-    replicas: 1
+    replicas: {{ .Values.replicaCount }}
     selector:
         matchLabels:
             app: {{ include "bctlquickstartchart.agentDeploymentName" . }}
@@ -84,5 +84,9 @@ spec:
             {{- end }}
             {{- with .Values.tolerations }}
             tolerations:
+                {{- toYaml . | nindent 16 }}
+            {{- end }}
+            {{- with .Values.agent.topologySpreadConstraints }}
+            topologySpreadConstraints:
                 {{- toYaml . | nindent 16 }}
             {{- end }}

--- a/charts/bctlquickstart/values.yaml
+++ b/charts/bctlquickstart/values.yaml
@@ -24,7 +24,7 @@ quickstart:
   create: true
   
   # The name of the service account to use.
-  quickstartServiceAccount: "bctl-quickstart-sa"
+  quickstartServiceAccount: ""
 
   # The name of the kube job to create
   # If not provided a default one will be created following  the name "bctl-{clusterName}-quickstart-job"

--- a/charts/bctlquickstart/values.yaml
+++ b/charts/bctlquickstart/values.yaml
@@ -41,6 +41,9 @@ agent:
   deploymentName: ""
   clusterName: ""
   clusterRoleName: ""
+  # Pod topology spread constraints for agent deployment
+  # ref. https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+  topologySpreadConstraints: []
 
 # Needed variables that must be set to register the agent
 apiKey: ""


### PR DESCRIPTION
## Description of the change

Also includes an [example values yaml file](https://github.com/bastionzero/charts/blob/35cc6caea7e5169d8a757a7e05ae1f4b23406c30/charts/bctlquickstart/example/multiple-replica.yaml) demonstrating how to use the  `replicaCount` and `topologySpreadConstraints` to create a highly available bzero agent deployment with multiple replicas that exist across cluster availability zones.

Closes #11 

## Relevant release note information

Release Notes:

## Related JIRA tickets

Relates to JIRA: CWC-2911

## Have you considered the security impacts?

Does this PR have any security impact?

- [ ] Yes
- [ ] No

If yes, please explain: